### PR TITLE
fix_category-js_in_item-registration-page

### DIFF
--- a/app/assets/javascripts/ancestry.js
+++ b/app/assets/javascripts/ancestry.js
@@ -1,8 +1,8 @@
 $(document).on("turbolinks:load", function () {
   // When selected main category, this method start.
-  $("select[name='item[category_id]']").change(function () {
-    $(".form_category").eq(2).remove();
-    $(".form_category").eq(1).remove();
+  $(document).on("change", ".category_0", function () {
+    // $(".form_category").eq(2).remove();
+    // $(".form_category").eq(1).remove();
 
     var ancestry = $(this).find("option:selected").val();
     $.ajax({
@@ -14,23 +14,38 @@ $(document).on("turbolinks:load", function () {
       dataType: "json",
     }).done(function (categories) {
       var html = "";
+      var htmlPrompt = "";
 
-      html += `<div class="container category_1__container"><div class="title"></div><div class="column form_category"><select name="item[category_id]" id="item[category_id]" class="category_1 text_box"><option value="${ancestry}">サブカテゴリを選ぶ</option>`;
+      if (categories.length == 0) {
+        html = `<option value>メインカテゴリを選んでください</option>`;
+        htmlPrompt = `<option value>メインカテゴリを選んでください</option>`;
+      } else {
+        html = `<option value>サブカテゴリ1を選ぶ</option>`;
 
-      $.each(categories, function (i, category) {
-        html += `<option value="${category.id}" ancestry="${category.ancestry}">${category.name}</option>`;
-      });
+        // html += `<div class="container category_1__container"><div class="title"></div><div class="column form_category"><select name="item[category_id]" id="item[category_id]" class="category_1 text_box"><option value="${ancestry}">サブカテゴリを選ぶ</option>`;
 
-      html += `</select></div></div>`;
-      $(".category_0__container").after(html);
-      $(".form_category").eq(1).hide().fadeIn(300);
+        $.each(categories, function (i, category) {
+          html += `<option value="${category.id}" ancestry="${category.ancestry}">${category.name}</option>`;
+        });
+        htmlPrompt = `<option value>サブカテゴリ1を選んでください</option>`;
+      }
+
+      // if (categories.length() == 0) {
+      //   `<option value>メインカテゴリを選んでください</option>`;
+      // } else {
+      // }
+      // html += `</select></div></div>`;
+      $(".category_1").empty();
+      $(".category_2").empty();
+      $(".category_1").append(html);
+      $(".category_2").append(htmlPrompt);
+      // $(".form_category").eq(1).hide().fadeIn(300);
     });
   });
 
   // When selected sub category, this method start.
   $(document).on("change", ".category_1", function () {
-    $(".form_category").eq(2).remove();
-    var parent = $(this).find("option:selected").val();
+    // $(".form_category").eq(2).remove();
     var ancestry =
       $(this).find("option:selected").attr("ancestry") +
       "/" +
@@ -45,15 +60,17 @@ $(document).on("turbolinks:load", function () {
       dataType: "json",
     }).done(function (categories) {
       var html = "";
+      html = `<option value>サブカテゴリ2を選ぶ</option>`;
 
-      html += `<div class="container category_2__container"><div class="title"></div><div class="column form_category"><select name="item[category_id]" id="item[category_id]" class="category_2 text_box"><option value="${parent}">サブカテゴリを選ぶ</option>`;
+      // html += `<div class="container category_2__container"><div class="title"></div><div class="column form_category"><select name="item[category_id]" id="item[category_id]" class="category_2 text_box"><option value="${parent}">サブカテゴリを選ぶ</option>`;
       $.each(categories, function (i, category) {
         html += `<option value="${category.id}" ancestry="${category.ancestry}">${category.name}</option>`;
       });
 
-      html += `</select></div></div>`;
-      $(".category_1__container").after(html);
-      $(".form_category").eq(2).hide().fadeIn(300);
+      // html += `</select></div></div>`;
+      $(".category_2").empty();
+      $(".category_2").append(html);
+      // $(".form_category").eq(2).hide().fadeIn(300);
     });
   });
 });

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -45,6 +45,14 @@
             必須
         .column.form_category
           = f.collection_select :category_id, Category.where(ancestry: nil), :id, :name, {prompt: "メインカテゴリを選ぶ"}, {class: "category_0 text_box"}
+      .container.category_1__container
+        .title
+        .column.form_category
+          = f.collection_select :category_id, {}, :id, :name, {prompt: "メインカテゴリを選んでください"}, {class: "category_1 text_box"}
+      .container.category_2__container
+        .title
+        .column.form_category
+          = f.collection_select :category_id, {}, :id, :name, {prompt: "メインカテゴリを選んでください"}, {class: "category_2 text_box"}
       .container
         .title
           .title__header


### PR DESCRIPTION
## what
- ancestry.jsのempty操作をappend操作の直前に移動
→ajaxの二重送信の際に次のカテゴリが2重で表示される可能性を限りなく小さくする
- 出品ページのhamlを修正
→ セレクトボックスをあらかじめ表示しておく

## why
- サブカテゴリ2のセレクトボックスが複数挿入されてしまうエラーを修正
- セレクトボックスごと追加される不自然な動作ではなく、元々用意されたセレクトボックスに次レベルカテゴリの項目を追加する仕様に変更