### PR TITLE
add_login_check_function_&_add_login_check_to_item_registration_page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,6 +30,12 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :firstname, :lastname, :firstname_read, :lastname_read, :birthday, address_attributes: [:firstname, :lastname, :firstname_read, :lastname_read, :zip, :prefecture, :city, :address_line, :building, :room, :telephone]])
   end
 
+  def confirm_user_signed_in?
+    if user_signed_in?
+    else
+      redirect_to root_path, notice: 'ログイン後、操作してください'
+    end
+  end
 
 end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,6 @@
 class ItemsController < ApplicationController
+  before_action :confirm_user_signed_in?, except: [:index, :show]
+
   def index
     @items = Item.all
   end


### PR DESCRIPTION
## what
- applicationコントローラにユーザーログインしていない場合にトップページにリダイレクトするアクションを追加
- itemコントローラに上記コントローラを呼び出す記述を追加（before_action）

## why
- ログイン確認用メソッドを追加
- 商品出品ページへのアクセスおよび商品登録時、ユーザーログインできていない場合、操作できないように

※なぜルートにリダイレクトするのか？
ユーザー登録しているユーザと登録しているがログインしていないユーザどちらにも対応するため。ログイン画面に、ユーザー登録画面に誘導できるようなリンクを作成すれば変更も一案