### PR TITLE
トップページのビュー修正

### DIFF
--- a/app/assets/javascripts/preview.js
+++ b/app/assets/javascripts/preview.js
@@ -102,12 +102,12 @@ $(document).on("turbolinks:load", function () {
       return false;
     }
     if ($(".category_1").val() === "") {
-      alert("カテゴリーを選択してください！");
+      alert("サブカテゴリー１を選択してください！");
       $(this).focus();
       return false;
     }
     if ($(".category_2").val() === "") {
-      alert("カテゴリーを選択してください！");
+      alert("サブカテゴリー２を選択してください！");
       $(this).focus();
       return false;
     }

--- a/app/assets/javascripts/preview.js
+++ b/app/assets/javascripts/preview.js
@@ -101,6 +101,16 @@ $(document).on("turbolinks:load", function () {
       $(this).focus();
       return false;
     }
+    if ($(".category_1").val() === "") {
+      alert("カテゴリーを選択してください！");
+      $(this).focus();
+      return false;
+    }
+    if ($(".category_2").val() === "") {
+      alert("カテゴリーを選択してください！");
+      $(this).focus();
+      return false;
+    }
     if ($(".condition").val() === "yyy") {
       alert("コンディションを選択してください！");
       $(this).focus();

--- a/app/assets/stylesheets/_top_page.scss
+++ b/app/assets/stylesheets/_top_page.scss
@@ -5,9 +5,11 @@ body {
   min-width: 940px;
   font-family: "Source Sans Pro", Helvetica, Arial, "游ゴシック体", "YuGothic",
     "メイリオ", "Meiryo", sans-serif;
+  background-color: #eeeeee;
 }
 .top_page {
   padding: 0 60px;
+  background-color: #eeeeee;
   &__header {
     max-width: 1040px;
     margin: 0 auto;
@@ -22,6 +24,7 @@ body {
       .search_box {
         display: flex;
         width: 100%;
+        margin-top: 23px;
         &__input {
           height: 36px;
           width: 100%;
@@ -42,7 +45,6 @@ body {
     .list {
       font-size: 14px;
       display: flex;
-      margin-bottom: 10px;
       justify-content: space-between;
       height: 32px;
       line-height: 32px;
@@ -98,6 +100,7 @@ body {
 }
 .reason {
   padding: 60px 20px;
+  background-color: #eeeeee;
   &__title {
     text-align: center;
     height: 50px;
@@ -180,6 +183,7 @@ body {
 }
 .buyAndsell {
   padding: 60px 100px;
+  background-color: #eeeeee;
   &__title {
     text-align: center;
     height: 50px;
@@ -248,14 +252,14 @@ body {
   }
   .topiclists {
     display: flex;
-    width: 780px;
+    width: 880px;
     margin: 0 auto;
     overflow-x: scroll;
-    background-color: #fff;
     .topiclist {
       width: 220px;
       min-width: 220px;
       display: flex;
+      background-color: #fff;
       &__item__img{
         height: 150px;
         width:220px;

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,7 +2,7 @@ class Item < ApplicationRecord
   validates_associated :images, presence: {message: "は1枚以上は登録してください"}
   validates :name, presence: {message: "が空欄です"}, length: {maximum: 40, message: "は40文字以内で入力してください"}
   validates :explanation, presence: {message: "が空欄です"}, length: {maximum: 1000, message: "は1000文字以内で入力してください"}
-  validates :category_id, presence: {message: "は少なくともメイングループから1つ選択してください"}
+  validates :category_id, presence: {message: "を選択してください"}
   validates :condition, presence: {message: "が空欄です：システムエラーのため管理者に連絡してください"}, exclusion: {in: %w(yyy), message: "が選択されていません"}
   validates :shipping_area, presence: {message: "が空欄です：システムエラーのため管理者に連絡してください"}, exclusion: {in: %w(xxx), message: "が選択されていません"}
   validates :shipping_pay, :shipping_period, presence: {message: "が空欄です：システムエラーのため管理者に連絡してください"}

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -114,8 +114,8 @@
         =link_to "/" do
           %h3.Title 新規投稿商品
       .topiclists
-        .topiclist
-          - @items.each do |item|
+        - @items.each do |item|
+          .topiclist
             =link_to item_path(id: item.id) ,class:"topiclist__item" do
               -item.images.first(1).each do |image|
                 = image_tag image.image.url, class:"topiclist__item__img"
@@ -127,7 +127,7 @@
                     %li
                       %i{class:"fa fa-star likeicon"}0
                   %p （税込） 
-          = paginate(@items) 
+        = paginate(@items) 
 
   %section.topic_brand
     %h2.topic_head ピックアップブランド

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :category do
     sequence(:name) {|n| "name#{n}"}
-    sequence(:ancestry) {|n| "name#{n}"}
+    sequence(:ancestry) {|n| "#{n}"}
 
     trait :with_category1 do
       sequence(:ancestry) {|n| "name#{n}"}

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     explanation {"力作です"}
     price {1800}
     condition {"damaged"}
-    image {[ Rack::Test::UploadedFile.new(Rails.root.join('spec/factories/_test.jpg'), 'spec/factories/_test.jpg') ]}
+    # image {[ Rack::Test::UploadedFile.new(Rails.root.join('spec/factories/_test.jpg'), 'spec/factories/_test.jpg') ]}
     shipping_pay {"exhibitor"}
     shipping_area {"yamaguchi"}
     shipping_period {"days1_2"}

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Item, type: :model do
       end
       context "categoryが入力されていない" do
         let(:category_id) {nil}
-        it {is_expected.to include("は少なくともメイングループから1つ選択してください")}
+        it {is_expected.to include("を選択してください")}
       end
     end
   end


### PR DESCRIPTION
what
マージ後に起きたビュー崩れの修正(トップページヘッダー部分、一覧表示部、全体の背景色)
出品時、子カテゴリーのエラーメッセージが出ないのを修正
出品ページのビュー崩れは編集機能作成時にまとめてやります。

why
ビュー崩れが起きていたから
バリデーションはかけていたがエラ〜メッセージが親カテゴリーにしか対応してなかった。