### PR TITLE
ユーザー新規登録のエラーメッセージをカッコよく！

### DIFF
--- a/app/assets/stylesheets/users/registration.scss
+++ b/app/assets/stylesheets/users/registration.scss
@@ -35,7 +35,7 @@
         font-family: "M PLUS 1p", sans-serif;
       }
       &__form-area {
-        margin: 20px 0;
+        // margin: 20px 0;
         padding: 3px 10px;
         align-items: center;
         &__name {

--- a/app/assets/stylesheets/users/registration.scss
+++ b/app/assets/stylesheets/users/registration.scss
@@ -35,9 +35,11 @@
         font-family: "M PLUS 1p", sans-serif;
       }
       &__form-area {
-        // margin: 20px 0;
         padding: 3px 10px;
         align-items: center;
+        &_color {
+          color: red;
+        }
         &__name {
           display: flex;
           margin: 5px 0;

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,5 @@
 class User < ApplicationRecord
-  validates :nickname, :firstname, :lastname, :firstname_read, :lastname_read, :birthday, :password, presence: {message: "が空欄です"}
-  validates :firstname, :lastname, format: { with: /\A[一-龥ぁ-ん]/, message: "は全角で入力してください"}
+  validates :nickname, :firstname, :lastname, :firstname_read, :lastname_read, :birthday, :password, presence: true
   validates :firstname_read, :lastname_read, format: { with: /\A[ぁ-んー－]+\z/, message: "は全角(ひらがな)で入力してください"}
 
   validates :password, length: { minimum:7, message: "は7文字以上で入力してください"}, confirmation: {message: "の値が一致しません"}

--- a/app/views/layouts/_error_messages.html.haml
+++ b/app/views/layouts/_error_messages.html.haml
@@ -1,5 +1,6 @@
-- if model.errors.any?
-  .error_message
-    - model.errors.full_messages.each do |message|
-      .error_message
-        =message
+-# - if model.errors.any?
+-#   - binding.pry
+-#   .error_message
+-#     - model.errors.full_messages.each do |message|
+-#       .error_message
+-#         =message

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -16,6 +16,10 @@
           .wrapper-sign-up__article__section__form-area__form
             =f.text_field :nickname, class: "wrapper-sign-up__article__section__form-area__form--style"
         .wrapper-sign-up__article__section__form-area
+          - if @user.errors.any?
+            - if @user.errors[:nickname]
+              .wrapper-sign-up__article__section__form-area
+                = @user.errors.full_messages[0]
           .wrapper-sign-up__article__section__form-area__name
             メールアドレス
             .wrapper-sign-up__article__section__form-area__name__attribute--box
@@ -23,6 +27,10 @@
           .wrapper-sign-up__article__section__form-area__form
             =f.email_field :email, class: "wrapper-sign-up__article__section__form-area__form--style"
         .wrapper-sign-up__article__section__form-area
+          - if @user.errors.any?
+            - if @user.errors[:email]
+              .wrapper-sign-up__article__section__form-area
+                = @user.errors.full_messages[12]
           .wrapper-sign-up__article__section__form-area__name
             パスワード
             .wrapper-sign-up__article__section__form-area__name__attribute--box
@@ -30,6 +38,12 @@
           .wrapper-sign-up__article__section__form-area__form
             =f.password_field :password, class: "wrapper-sign-up__article__section__form-area__form--style", placeholder: "7文字以上"
         .wrapper-sign-up__article__section__form-area
+          - if @user.errors.any?
+            - if @user.errors[:password]
+              .wrapper-sign-up__article__section__form-area
+                = @user.errors.full_messages[9]
+                = @user.errors.full_messages[10]
+                = @user.errors.full_messages[11]
           .wrapper-sign-up__article__section__form-area__name
             パスワード(確認用)
             .wrapper-sign-up__article__section__form-area__name__attribute--box
@@ -52,6 +66,16 @@
               .wrapper-sign-up__article__section__form-area__form__divide__text 名
               =f.text_field :firstname, class: "wrapper-sign-up__article__section__form-area__form--style", placeholder: "全角"
         .wrapper-sign-up__article__section__form-area
+          - if @user.errors.any?
+            - if @user.errors[:lastname]
+              .wrapper-sign-up__article__section__form-area
+                = @user.errors.full_messages[3]
+                = @user.errors.full_messages[4]
+          - if @user.errors.any?
+            - if @user.errors[:fastname]
+              .wrapper-sign-up__article__section__form-area
+                = @user.errors.full_messages[1]
+                = @user.errors.full_messages[2]
           .wrapper-sign-up__article__section__form-area__name
             ふりがな
             .wrapper-sign-up__article__section__form-area__name__attribute--box
@@ -64,6 +88,16 @@
               .wrapper-sign-up__article__section__form-area__form__divide__text 名
               =f.text_field :firstname_read, class: "wrapper-sign-up__article__section__form-area__form--style", placeholder: "全角"
         .wrapper-sign-up__article__section__form-area
+          - if @user.errors.any?
+            - if @user.errors[:lastname_read]
+              .wrapper-sign-up__article__section__form-area
+                = @user.errors.full_messages[7]
+                = @user.errors.full_messages[8]
+          - if @user.errors.any?
+            - if @user.errors[:fastname_read]
+              .wrapper-sign-up__article__section__form-area
+                = @user.errors.full_messages[5]
+                = @user.errors.full_messages[6]
           .wrapper-sign-up__article__section__form-area__name
             誕生日
             .wrapper-sign-up__article__section__form-area__name__attribute--box
@@ -87,6 +121,16 @@
                 .wrapper-sign-up__article__section__form-area__form__divide__text 名
                 =address_f.text_field :firstname, class: "wrapper-sign-up__article__section__form-area__form--style"
           .wrapper-sign-up__article__section__form-area
+            - if @user.errors.any?
+              - if @user.errors[:lastname]
+                .wrapper-sign-up__article__section__form-area
+                  = @user.errors.full_messages[3]
+                  = @user.errors.full_messages[4]
+            - if @user.errors.any?
+              - if @user.errors[:fastname]
+                .wrapper-sign-up__article__section__form-area
+                  = @user.errors.full_messages[1]
+                  = @user.errors.full_messages[2]
             .wrapper-sign-up__article__section__form-area__name
               ふりがな
               .wrapper-sign-up__article__section__form-area__name__attribute--box
@@ -99,6 +143,16 @@
                 .wrapper-sign-up__article__section__form-area__form__divide__text 名
                 =address_f.text_field :firstname_read, class: "wrapper-sign-up__article__section__form-area__form--style"
           .wrapper-sign-up__article__section__form-area
+            - if @user.errors.any?
+              - if @user.errors[:lastname_read]
+                .wrapper-sign-up__article__section__form-area
+                  = @user.errors.full_messages[7]
+                  = @user.errors.full_messages[8]
+            - if @user.errors.any?
+              - if @user.errors[:fastname_read]
+                .wrapper-sign-up__article__section__form-area
+                  = @user.errors.full_messages[5]
+                  = @user.errors.full_messages[6]
             .wrapper-sign-up__article__section__form-area__name
               郵便番号
               .wrapper-sign-up__article__section__form-area__name__attribute--box
@@ -108,6 +162,14 @@
               .wrapper-sign-up__article__section__form-area__form--zip-divide -
               =address_f.text_field :last_zip, class: "wrapper-sign-up__article__section__form-area__form--style wrapper-sign-up__article__section__form-area__form--zip-second", maxlength: "4"
           .wrapper-sign-up__article__section__form-area
+            - if @user.errors.any?
+              - if @user.errors[:first_zip]
+                .wrapper-sign-up__article__section__form-area
+                  = @user.errors.full_messages[23]
+            - if @user.errors.any?
+              - if @user.errors[:last_zip]
+                .wrapper-sign-up__article__section__form-area
+                  = @user.errors.full_messages[23]
             .wrapper-sign-up__article__section__form-area__name
               都道府県
               .wrapper-sign-up__article__section__form-area__name__attribute--box
@@ -115,6 +177,10 @@
             .wrapper-sign-up__article__section__form-area__form
               =address_f.text_field :prefecture, class: "wrapper-sign-up__article__section__form-area__form--style"
           .wrapper-sign-up__article__section__form-area
+            - if @user.errors.any?
+              - if @user.errors[:prefecture]
+                .wrapper-sign-up__article__section__form-area
+                  = @user.errors.full_messages[0]
             .wrapper-sign-up__article__section__form-area__name
               市区町村
               .wrapper-sign-up__article__section__form-area__name__attribute--box
@@ -122,6 +188,10 @@
             .wrapper-sign-up__article__section__form-area__form
               =address_f.text_field :city, class: "wrapper-sign-up__article__section__form-area__form--style"
           .wrapper-sign-up__article__section__form-area
+            - if @user.errors.any?
+              - if @user.errors[:city]
+                .wrapper-sign-up__article__section__form-area
+                = @user.errors.full_messages[0]
             .wrapper-sign-up__article__section__form-area__name
               番地
               .wrapper-sign-up__article__section__form-area__name__attribute--box
@@ -129,6 +199,9 @@
             .wrapper-sign-up__article__section__form-area__form
               =address_f.text_field :address_line, class: "wrapper-sign-up__article__section__form-area__form--style"
           .wrapper-sign-up__article__section__form-area
+            - if @user.errors.any?
+              - if @user.errors[:address_line]
+                = @user.errors.full_messages[0]
             .wrapper-sign-up__article__section__form-area__name
               建物名
               .wrapper-sign-up__article__section__form-area__name__attribute--box.wrapper-sign-up__article__section__form-area__name__attribute--optional

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -18,8 +18,9 @@
         .wrapper-sign-up__article__section__form-area
           - if @user.errors.any?
             - if @user.errors[:nickname]
-              .wrapper-sign-up__article__section__form-area
-                = @user.errors.full_messages[0]
+              .wrapper-sign-up__article__section__form-area_color
+                ニックネーム
+                = @user.errors.messages[:nickname][0]
           .wrapper-sign-up__article__section__form-area__name
             メールアドレス
             .wrapper-sign-up__article__section__form-area__name__attribute--box
@@ -29,8 +30,9 @@
         .wrapper-sign-up__article__section__form-area
           - if @user.errors.any?
             - if @user.errors[:email]
-              .wrapper-sign-up__article__section__form-area
-                = @user.errors.full_messages[12]
+              .wrapper-sign-up__article__section__form-area_color
+                メールアドレス
+                = @user.errors.messages[:email][0]
           .wrapper-sign-up__article__section__form-area__name
             パスワード
             .wrapper-sign-up__article__section__form-area__name__attribute--box
@@ -40,10 +42,9 @@
         .wrapper-sign-up__article__section__form-area
           - if @user.errors.any?
             - if @user.errors[:password]
-              .wrapper-sign-up__article__section__form-area
-                = @user.errors.full_messages[9]
-                = @user.errors.full_messages[10]
-                = @user.errors.full_messages[11]
+              .wrapper-sign-up__article__section__form-area_color
+                パスワード
+                = @user.errors.messages[:password][1]
           .wrapper-sign-up__article__section__form-area__name
             パスワード(確認用)
             .wrapper-sign-up__article__section__form-area__name__attribute--box
@@ -68,14 +69,15 @@
         .wrapper-sign-up__article__section__form-area
           - if @user.errors.any?
             - if @user.errors[:lastname]
-              .wrapper-sign-up__article__section__form-area
-                = @user.errors.full_messages[3]
-                = @user.errors.full_messages[4]
+              .wrapper-sign-up__article__section__form-area_color
+                名前(姓)
+                = @user.errors.messages[:lastname][1]
           - if @user.errors.any?
             - if @user.errors[:fastname]
-              .wrapper-sign-up__article__section__form-area
-                = @user.errors.full_messages[1]
-                = @user.errors.full_messages[2]
+              .wrapper-sign-up__article__section__form-area_color
+                名前(名)
+                = @user.errors.messages[:firstname][1]
+                
           .wrapper-sign-up__article__section__form-area__name
             ふりがな
             .wrapper-sign-up__article__section__form-area__name__attribute--box
@@ -90,14 +92,14 @@
         .wrapper-sign-up__article__section__form-area
           - if @user.errors.any?
             - if @user.errors[:lastname_read]
-              .wrapper-sign-up__article__section__form-area
-                = @user.errors.full_messages[7]
-                = @user.errors.full_messages[8]
+              .wrapper-sign-up__article__section__form-area_color
+                ふりがな(姓)
+                = @user.errors.messages[:lastname_read][1]
           - if @user.errors.any?
             - if @user.errors[:fastname_read]
-              .wrapper-sign-up__article__section__form-area
-                = @user.errors.full_messages[5]
-                = @user.errors.full_messages[6]
+              .wrapper-sign-up__article__section__form-area_color
+                ふりがな(名)
+                = @user.errors.messages[:firstname_read][1]    
           .wrapper-sign-up__article__section__form-area__name
             誕生日
             .wrapper-sign-up__article__section__form-area__name__attribute--box
@@ -123,14 +125,14 @@
           .wrapper-sign-up__article__section__form-area
             - if @user.errors.any?
               - if @user.errors[:lastname]
-                .wrapper-sign-up__article__section__form-area
-                  = @user.errors.full_messages[3]
-                  = @user.errors.full_messages[4]
+                .wrapper-sign-up__article__section__form-area_color
+                  名前(姓)
+                  = @user.errors.messages[:lastname][1]
             - if @user.errors.any?
               - if @user.errors[:fastname]
-                .wrapper-sign-up__article__section__form-area
-                  = @user.errors.full_messages[1]
-                  = @user.errors.full_messages[2]
+                .wrapper-sign-up__article__section__form-area_color
+                  名前(名)
+                  = @user.errors.messages[:firstname][1]                 
             .wrapper-sign-up__article__section__form-area__name
               ふりがな
               .wrapper-sign-up__article__section__form-area__name__attribute--box
@@ -145,14 +147,14 @@
           .wrapper-sign-up__article__section__form-area
             - if @user.errors.any?
               - if @user.errors[:lastname_read]
-                .wrapper-sign-up__article__section__form-area
-                  = @user.errors.full_messages[7]
-                  = @user.errors.full_messages[8]
+                .wrapper-sign-up__article__section__form-area_color
+                  ふりがな(姓)
+                  = @user.errors.messages[:lastname_read][1]
             - if @user.errors.any?
               - if @user.errors[:fastname_read]
-                .wrapper-sign-up__article__section__form-area
-                  = @user.errors.full_messages[5]
-                  = @user.errors.full_messages[6]
+                .wrapper-sign-up__article__section__form-area_color
+                  ふりがな(名)
+                  = @user.errors.messages[:firstname_read][1] 
             .wrapper-sign-up__article__section__form-area__name
               郵便番号
               .wrapper-sign-up__article__section__form-area__name__attribute--box
@@ -164,12 +166,9 @@
           .wrapper-sign-up__article__section__form-area
             - if @user.errors.any?
               - if @user.errors[:first_zip]
-                .wrapper-sign-up__article__section__form-area
-                  = @user.errors.full_messages[23]
-            - if @user.errors.any?
-              - if @user.errors[:last_zip]
-                .wrapper-sign-up__article__section__form-area
-                  = @user.errors.full_messages[23]
+                .wrapper-sign-up__article__section__form-area_color
+                  郵便番号
+                  = @user.errors.messages[:"addresses.zip"][0]
             .wrapper-sign-up__article__section__form-area__name
               都道府県
               .wrapper-sign-up__article__section__form-area__name__attribute--box
@@ -179,8 +178,9 @@
           .wrapper-sign-up__article__section__form-area
             - if @user.errors.any?
               - if @user.errors[:prefecture]
-                .wrapper-sign-up__article__section__form-area
-                  = @user.errors.full_messages[0]
+                .wrapper-sign-up__article__section__form-area_color
+                  都道府県
+                  = @user.errors.messages[:"addresses.prefecture"][0]
             .wrapper-sign-up__article__section__form-area__name
               市区町村
               .wrapper-sign-up__article__section__form-area__name__attribute--box
@@ -190,8 +190,9 @@
           .wrapper-sign-up__article__section__form-area
             - if @user.errors.any?
               - if @user.errors[:city]
-                .wrapper-sign-up__article__section__form-area
-                = @user.errors.full_messages[0]
+                .wrapper-sign-up__article__section__form-area_color
+                  市町村
+                  = @user.errors.messages[:"addresses.city"][0]
             .wrapper-sign-up__article__section__form-area__name
               番地
               .wrapper-sign-up__article__section__form-area__name__attribute--box
@@ -201,9 +202,11 @@
           .wrapper-sign-up__article__section__form-area
             - if @user.errors.any?
               - if @user.errors[:address_line]
-                = @user.errors.full_messages[0]
-            .wrapper-sign-up__article__section__form-area__name
-              建物名
+                .wrapper-sign-up__article__section__form-area_color
+                  番地
+                  = @user.errors.messages[:"addresses.address_line"][0]
+              .wrapper-sign-up__article__section__form-area__name
+                建物名
               .wrapper-sign-up__article__section__form-area__name__attribute--box.wrapper-sign-up__article__section__form-area__name__attribute--optional
                 任意
             .wrapper-sign-up__article__section__form-area__form

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -17,7 +17,7 @@
             =f.text_field :nickname, class: "wrapper-sign-up__article__section__form-area__form--style"
         .wrapper-sign-up__article__section__form-area
           - if @user.errors.any?
-            - if @user.errors[:nickname]
+            - if @user.errors[:nickname].present?
               .wrapper-sign-up__article__section__form-area_color
                 ニックネーム
                 = @user.errors.messages[:nickname][0]
@@ -29,7 +29,7 @@
             =f.email_field :email, class: "wrapper-sign-up__article__section__form-area__form--style"
         .wrapper-sign-up__article__section__form-area
           - if @user.errors.any?
-            - if @user.errors[:email]
+            - if @user.errors[:email].present?
               .wrapper-sign-up__article__section__form-area_color
                 メールアドレス
                 = @user.errors.messages[:email][0]
@@ -41,7 +41,7 @@
             =f.password_field :password, class: "wrapper-sign-up__article__section__form-area__form--style", placeholder: "7文字以上"
         .wrapper-sign-up__article__section__form-area
           - if @user.errors.any?
-            - if @user.errors[:password]
+            - if @user.errors[:password].present?
               .wrapper-sign-up__article__section__form-area_color
                 パスワード
                 = @user.errors.messages[:password][1]
@@ -67,17 +67,16 @@
               .wrapper-sign-up__article__section__form-area__form__divide__text 名
               =f.text_field :firstname, class: "wrapper-sign-up__article__section__form-area__form--style", placeholder: "全角"
         .wrapper-sign-up__article__section__form-area
-          - if @user.errors.any?
-            - if @user.errors[:lastname]
+          -if @user.errors.any?
+            - if @user.errors[:lastname].present?
               .wrapper-sign-up__article__section__form-area_color
                 名前(姓)
-                = @user.errors.messages[:lastname][1]
+                = @user.errors.messages[:lastname][0]
           - if @user.errors.any?
-            - if @user.errors[:fastname]
+            - if @user.errors[:firstname].present?
               .wrapper-sign-up__article__section__form-area_color
                 名前(名)
-                = @user.errors.messages[:firstname][1]
-                
+                = @user.errors.messages[:firstname][0]  
           .wrapper-sign-up__article__section__form-area__name
             ふりがな
             .wrapper-sign-up__article__section__form-area__name__attribute--box
@@ -91,12 +90,12 @@
               =f.text_field :firstname_read, class: "wrapper-sign-up__article__section__form-area__form--style", placeholder: "全角"
         .wrapper-sign-up__article__section__form-area
           - if @user.errors.any?
-            - if @user.errors[:lastname_read]
+            - if @user.errors[:lastname_read].present?
               .wrapper-sign-up__article__section__form-area_color
                 ふりがな(姓)
                 = @user.errors.messages[:lastname_read][1]
           - if @user.errors.any?
-            - if @user.errors[:fastname_read]
+            - if @user.errors[:firstname_read].present?
               .wrapper-sign-up__article__section__form-area_color
                 ふりがな(名)
                 = @user.errors.messages[:firstname_read][1]    
@@ -124,15 +123,15 @@
                 =address_f.text_field :firstname, class: "wrapper-sign-up__article__section__form-area__form--style"
           .wrapper-sign-up__article__section__form-area
             - if @user.errors.any?
-              - if @user.errors[:lastname]
+              - if @user.errors[:"addresses.lastname"].present?
                 .wrapper-sign-up__article__section__form-area_color
-                  名前(姓)
-                  = @user.errors.messages[:lastname][1]
+                  名前（姓）
+                  = @user.errors.messages[:"addresses.lastname"][0]
             - if @user.errors.any?
-              - if @user.errors[:fastname]
+              - if @user.errors[:"addresses.firstname"].present?
                 .wrapper-sign-up__article__section__form-area_color
                   名前(名)
-                  = @user.errors.messages[:firstname][1]                 
+                  = @user.errors.messages[:"addresses.firstname"][0]                 
             .wrapper-sign-up__article__section__form-area__name
               ふりがな
               .wrapper-sign-up__article__section__form-area__name__attribute--box
@@ -146,15 +145,15 @@
                 =address_f.text_field :firstname_read, class: "wrapper-sign-up__article__section__form-area__form--style"
           .wrapper-sign-up__article__section__form-area
             - if @user.errors.any?
-              - if @user.errors[:lastname_read]
+              - if @user.errors[:"addresses.lastname_read"].present?
                 .wrapper-sign-up__article__section__form-area_color
                   ふりがな(姓)
-                  = @user.errors.messages[:lastname_read][1]
+                  = @user.errors.messages[:"addresses.lastname_read"][1]
             - if @user.errors.any?
-              - if @user.errors[:fastname_read]
+              - if @user.errors[:"addresses.firstname_read"].present?
                 .wrapper-sign-up__article__section__form-area_color
                   ふりがな(名)
-                  = @user.errors.messages[:firstname_read][1] 
+                  = @user.errors.messages[:"addresses.firstname_read"][1] 
             .wrapper-sign-up__article__section__form-area__name
               郵便番号
               .wrapper-sign-up__article__section__form-area__name__attribute--box
@@ -165,7 +164,7 @@
               =address_f.text_field :last_zip, class: "wrapper-sign-up__article__section__form-area__form--style wrapper-sign-up__article__section__form-area__form--zip-second", maxlength: "4"
           .wrapper-sign-up__article__section__form-area
             - if @user.errors.any?
-              - if @user.errors[:first_zip]
+              - if @user.errors[:"addresses.zip"].present?
                 .wrapper-sign-up__article__section__form-area_color
                   郵便番号
                   = @user.errors.messages[:"addresses.zip"][0]
@@ -177,7 +176,7 @@
               =address_f.text_field :prefecture, class: "wrapper-sign-up__article__section__form-area__form--style"
           .wrapper-sign-up__article__section__form-area
             - if @user.errors.any?
-              - if @user.errors[:prefecture]
+              - if @user.errors[:"addresses.prefecture"].present?
                 .wrapper-sign-up__article__section__form-area_color
                   都道府県
                   = @user.errors.messages[:"addresses.prefecture"][0]
@@ -189,7 +188,7 @@
               =address_f.text_field :city, class: "wrapper-sign-up__article__section__form-area__form--style"
           .wrapper-sign-up__article__section__form-area
             - if @user.errors.any?
-              - if @user.errors[:city]
+              - if @user.errors[:"addresses.city"].present?
                 .wrapper-sign-up__article__section__form-area_color
                   市町村
                   = @user.errors.messages[:"addresses.city"][0]
@@ -201,7 +200,7 @@
               =address_f.text_field :address_line, class: "wrapper-sign-up__article__section__form-area__form--style"
           .wrapper-sign-up__article__section__form-area
             - if @user.errors.any?
-              - if @user.errors[:address_line]
+              - if @user.errors[:"addresses.address_line"].present?
                 .wrapper-sign-up__article__section__form-area_color
                   番地
                   = @user.errors.messages[:"addresses.address_line"][0]


### PR DESCRIPTION
#WHAT
エラーメッセージを各入力欄の下に設定
エラーメッセージの文字色を赤に変更
入力欄とエラーメッセーの隙間を埋める
if文を使って入力、未入力時のエラーメッセージ表示の設定

#WHY
エラーメッセージをカッコよく見せるため！