### PR TITLE
購入確認ページ修正

### DIFF
--- a/app/assets/stylesheets/purchases/confirm.scss
+++ b/app/assets/stylesheets/purchases/confirm.scss
@@ -25,7 +25,7 @@
       width: 100%;
       position: relative;
       &__bar {
-        font-size: 22px;
+        font-size: 16px;
       }
       &__price {
         position: absolute;

--- a/app/views/purchases/confirm.html.haml
+++ b/app/views/purchases/confirm.html.haml
@@ -13,7 +13,7 @@
         = image_tag @item.images.first.image.url
       .items__title
         .items__title__bar
-          =@item.name
+          =@item.name.truncate(15)
         .items__title__price
           .items__title__price__board
             = "#{@item.price}円"


### PR DESCRIPTION
what
購入確認ページの表示される文字数を制限
why
文字数が多い時にビュー崩れが起きたから