### PR TITLE
パンくず追加

### DIFF
--- a/app/views/browsing_histories/index.html.haml
+++ b/app/views/browsing_histories/index.html.haml
@@ -1,5 +1,5 @@
 = render partial: 'layouts/header'
-- breadcrumb :user_show
+- breadcrumb :browsing_histories
 = render "layouts/breadcrumbs"
 .wrapper_mypage
   .contents__mypage

--- a/app/views/searches/_search.html.haml
+++ b/app/views/searches/_search.html.haml
@@ -1,5 +1,6 @@
 = render partial: 'layouts/header'
-
+- breadcrumb :search_index
+= render "layouts/breadcrumbs"
 .search_view
   = render partial: 'searches/form'
 

--- a/app/views/users/bought_items.html.haml
+++ b/app/views/users/bought_items.html.haml
@@ -1,5 +1,5 @@
 = render partial: 'layouts/header'
-- breadcrumb :user_show
+- breadcrumb :users_bought_items
 = render "layouts/breadcrumbs"
 .wrapper_mypage
   .contents__mypage

--- a/app/views/users/sale_items.html.haml
+++ b/app/views/users/sale_items.html.haml
@@ -1,5 +1,5 @@
 = render partial: 'layouts/header'
-- breadcrumb :user_show
+- breadcrumb :users_sale_items
 = render "layouts/breadcrumbs"
 .wrapper_mypage
   .contents__mypage

--- a/app/views/users/sold_items.html.haml
+++ b/app/views/users/sold_items.html.haml
@@ -1,5 +1,5 @@
 = render partial: 'layouts/header'
-- breadcrumb :user_show
+- breadcrumb :users_sold_items
 = render "layouts/breadcrumbs"
 .wrapper_mypage
   .contents__mypage

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -24,8 +24,8 @@ crumb :creditcard_show do
   parent :user_show
 end
 
-crumb :item_search do
-  link "検索結果一覧", search_items_path
+crumb :search_index do
+  link "検索結果一覧", searches_path
 end
 
 crumb :item_show do
@@ -44,6 +44,26 @@ end
 
 crumb :item_new do
   link "商品の出品", new_item_path
+end
+
+crumb :users_bought_items do
+  link "購入した商品", bought_items_users_path
+  parent :user_show
+end
+
+crumb :users_sale_items do
+  link "出品中の商品", sale_items_users_path
+  parent :user_show
+end
+
+crumb :users_sold_items do
+  link "販売済の商品", sold_items_users_path
+  parent :user_show
+end
+
+crumb :browsing_histories do
+  link "閲覧履歴", browsing_histories_path
+  parent :user_show
 end
 
 # crumb :projects do


### PR DESCRIPTION
what
パンくずナビ機能実装時、存在しなかったページにパンくず追加
why
パンくずを全ページに網羅させるため