### PR TITLE
仕上げ

### DIFF
--- a/app/assets/stylesheets/items/show.scss
+++ b/app/assets/stylesheets/items/show.scss
@@ -251,8 +251,8 @@
 
       p{
         font-size: 18px;
-        text-align: right;
-        margin-right: 10px;
+        // text-align: right;
+        // margin-right: 10px;
         margin-top: 0px;
       }
 

--- a/app/views/browsing_histories/index.html.haml
+++ b/app/views/browsing_histories/index.html.haml
@@ -25,7 +25,11 @@
                           = history.item.price
                           円
                           %li
-                            %i{class:"fa fa-star likeicon"}0
+                            -# %i{class:"fa fa-star likeicon"}0
+                            -if history.item.shipping_pay == "exhibitor"
+                              送込
+                            - else
+                              送別
                         %p （税込）
                     -if history.item.status == "sold"
                       .sold_tag

--- a/app/views/favorites/index.html.haml
+++ b/app/views/favorites/index.html.haml
@@ -23,7 +23,11 @@
                         %ul
                           = "#{favorite.item.price} 円"
                           %li
-                            %i{class:"fa fa-star likeicon"}0
+                            -# %i{class:"fa fa-star likeicon"}0
+                            -if favorite.item.shipping_pay == "exhibitor"
+                              送込
+                            - else
+                              送別
                         %p （税込）
                     -if favorite.item.status == "sold"  
                       .sold_tag

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -101,7 +101,11 @@
                       = item.price
                       円
                       %li
-                        %i{class:"fa fa-star likeicon"}0
+                        -# %i{class:"fa fa-star likeicon"}0
+                        -if item.shipping_pay == "exhibitor"
+                          送込
+                        - else
+                          送別
                     %p （税込)
           .scroll
             = link_to_prev_page @items, '前', class: "prev"
@@ -125,7 +129,11 @@
                     = item.price
                     円
                     %li
-                      %i{class:"fa fa-star likeicon"}0
+                      -# %i{class:"fa fa-star likeicon"}0
+                      -if item.shipping_pay == "exhibitor"
+                        送込
+                      - else
+                        送別
                   %p （税込）
 
 = render partial: 'layouts/footer'

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -22,7 +22,7 @@
               = "#{@item.price}円"
             .itemBox__price-detail
               %span (税込)
-              %span 送料込
+              -# %span 送料込
           .btn-block
             -if @item.status == 'sold'
               .btn-block__purchase SOLD OUT
@@ -84,10 +84,10 @@
           .optionalArea
             %ul#favoriteBtn
               = render "favorites/favorite", item: @item
-            %ul.optional
-              %li.optionalBtn
-                = link_to "#" do
-                  %i.fa.fa-flag 不適切な商品の通報
+            -# %ul.optional
+            -#   %li.optionalBtn
+            -#     = link_to "#" do
+            -#       %i.fa.fa-flag 不適切な商品の通報
         .commentBox
           %p.noticeMsg
             相手のことを考え丁寧なコメントを心がけましょう。

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -15,7 +15,7 @@
         %li.list__left__category
           =link_to "カテゴリー", 'http://google.co.jp'
         %li.list__left__brand
-          =link_to "ブランド", 'http://google.co.jp'
+          =link_to "ブランド", searches_path
       %ul.list__right
         - if user_signed_in?
           %li.list__right__favorite

--- a/app/views/layouts/_sidemenu.html.haml
+++ b/app/views/layouts/_sidemenu.html.haml
@@ -22,13 +22,13 @@
         =link_to "購入した商品", bought_items_users_path
       %li.group-list__watch
         =link_to "最近見た商品", browsing_histories_path
-      %li.group-list__comment
-        =link_to "コメントした商品"
+      -# %li.group-list__comment
+      -#   =link_to "コメントした商品"
   %group
     %h2.side-menu__title 設定・ヘルプ・その他
     .group-list
-      %li.group-list__inquiry
-        =link_to "お問い合わせ"
+      -# %li.group-list__inquiry
+      -#   =link_to "お問い合わせ"
       %li.group-list__credit
         - if current_user.creditcards.empty?
           =link_to "クレジットカード情報の登録", new_creditcard_path

--- a/app/views/layouts/_sidemenu.html.haml
+++ b/app/views/layouts/_sidemenu.html.haml
@@ -3,7 +3,7 @@
     %h2.side-menu__title マイページメニュー
     .group-list
       %li.group-list__notice
-        =link_to "お知らせ", user_path(current_user)
+        =link_to "マイページ", user_path(current_user)
       %li.group-list__likes
         =link_to "お気に入り一覧", item_favorites_path(:item_id)
   %group
@@ -34,7 +34,7 @@
           =link_to "クレジットカード情報の登録", new_creditcard_path
         -else
           =link_to "クレジットカード情報の管理", creditcard_path(current_user.creditcards.first.id)
-      %li.group-list__management
-        =link_to "ポイント管理"
+      -# %li.group-list__management
+      -#   =link_to "ポイント管理"
       %li.group-list__logout
         =link_to "ログアウト",destroy_user_session_path, method: :delete, data: {confirm: "ログアウトします。よろしいですか？"}

--- a/app/views/searches/_search.html.haml
+++ b/app/views/searches/_search.html.haml
@@ -23,7 +23,11 @@
                       = item.price
                       円
                       %li
-                        %i{class:"fa fa-star likeicon"}0
+                        -# %i{class:"fa fa-star likeicon"}0
+                        -if item.shipping_pay == "exhibitor"
+                          送込
+                        - else
+                          送別
                     %p （税込）
           .item_scroll
             = link_to_prev_page @items, '前', class: "prev"

--- a/app/views/users/bought_items.html.haml
+++ b/app/views/users/bought_items.html.haml
@@ -24,7 +24,11 @@
                           = purchase.item.price
                           円
                           %li
-                            %i{class:"fa fa-star likeicon"}0
+                            -# %i{class:"fa fa-star likeicon"}0
+                            -if purchase.item.shipping_pay == "exhibitor"
+                              送込
+                            - else
+                              送別
                         %p （税込）
                     .sold_tag
                       .sold_tag__inner

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -1,6 +1,7 @@
 =render 'layouts/error_messages', model: @user
 .top_icon
-  =image_tag(asset_path("logo.png"))
+  =link_to "/" do
+    =image_tag(asset_path("logo.png"))
 - breadcrumb :sign_up
 = render "layouts/breadcrumbs"
 %main.wrapper-sign-up

--- a/app/views/users/sale_items.html.haml
+++ b/app/views/users/sale_items.html.haml
@@ -24,7 +24,11 @@
                           = item.price
                           円
                           %li
-                            %i{class:"fa fa-star likeicon"}0
+                            -# %i{class:"fa fa-star likeicon"}0
+                            -if item.shipping_pay == "exhibitor"
+                              送込
+                            - else
+                              送別
                         %p （税込）
               .item_scroll
                 = link_to_prev_page @items, '前', class: "prev"

--- a/app/views/users/sessions/new.html.haml
+++ b/app/views/users/sessions/new.html.haml
@@ -1,5 +1,6 @@
 .top_icon
-  =image_tag(asset_path("logo.png"))
+  =link_to "/" do
+    =image_tag(asset_path("logo.png"))
 - breadcrumb :sign_in
 = render "layouts/breadcrumbs"
 %main.wrapper-sign-in

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -38,7 +38,11 @@
                               = item.price
                               円
                               %li
-                                %i{class:"fa fa-star likeicon"}0
+                                -# %i{class:"fa fa-star likeicon"}0
+                                -if item.shipping_pay == "exhibitor"
+                                  送込
+                                - else
+                                  送別
                             %p （税込）
                         .sold_tag
                           .sold_tag__inner
@@ -68,7 +72,11 @@
                               = item.price
                               円
                               %li
-                                %i{class:"fa fa-star likeicon"}0
+                                -# %i{class:"fa fa-star likeicon"}0
+                                -if item.shipping_pay == "exhibitor"
+                                  送込
+                                - else
+                                  送別
                             %p （税込）
                         .sold_tag
                           .sold_tag__inner
@@ -98,7 +106,11 @@
                               = item.price
                               円
                               %li
-                                %i{class:"fa fa-star likeicon"}0
+                                -# %i{class:"fa fa-star likeicon"}0
+                                -if item.shipping_pay == "exhibitor"
+                                  送込
+                                - else
+                                  送別
                             %p （税込）
             - else
               %p.main-box__text                 
@@ -125,7 +137,11 @@
                               = history.item.price
                               円
                               %li
-                                %i{class:"fa fa-star likeicon"}0
+                                -# %i{class:"fa fa-star likeicon"}0
+                                -if history.item.shipping_pay == "exhibitor"
+                                  送込
+                                - else
+                                  送別
                             %p （税込）
                         -if history.item.status == "sold"
                           .sold_tag

--- a/app/views/users/sold_items.html.haml
+++ b/app/views/users/sold_items.html.haml
@@ -24,7 +24,11 @@
                           = item.price
                           円
                           %li
-                            %i{class:"fa fa-star likeicon"}0
+                            -# %i{class:"fa fa-star likeicon"}0
+                            -if item.shipping_pay == "exhibitor"
+                              送込
+                            - else
+                              送別
                         %p （税込）
                     .sold_tag
                       .sold_tag__inner


### PR DESCRIPTION
what
見た目の最終仕上げ
お気に入り用★カウント
→未実装のため送料表示に変更
ヘッダーのブランド
→一覧未実装のためリンク先を検索ページへ
ログインページなどのトップアイコンにトップページへのリンク付与
マイページ問合せ欄
→機能未実装のためコメントアウト
コメントした商品
→一覧未実装のためコメントアウト
不適切な商品
→機能未実装のためコメントアウト
商品詳細ログアウト時コメント欄端に寄ってたので真ん中に修正
why
未実装項目を表示しないため
削除では無くコメントアウトにしたのは追加実装したくなった時に1からやり直さなくていいようにするためです