### PR TITLE
購入画面編集先追加

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -26,6 +26,18 @@ class UsersController < ApplicationController
     @purchase.each do |purchase|
       @bought_items << purchase.item
     end
-
   end
-end
+
+  def edit
+    @user = User.find(params[:id])
+  end
+
+  def update
+    @user = User.find(params[:id])
+    @user.update(user_params)
+    redirect_to user_path, notice: '商品を編集しました'
+    else
+      render :edit
+    end
+  end
+

--- a/app/views/purchases/confirm.html.haml
+++ b/app/views/purchases/confirm.html.haml
@@ -31,7 +31,7 @@
       .payment_method__title
         .payment_method__title__bar
           クレジットカード
-        =link_to "変更する >", class: "change"
+        =link_to "変更する >", new_creditcard_path, class: "change"
       .credit_card
         .credit_card__no
         = "**** **** **** "+ @creditcard_payjp.last4
@@ -49,7 +49,7 @@
       .confirm_adress__title
         .confirm_adress__title__bar
           配送先
-        =link_to "変更する >", class: "change"
+        =link_to "変更する >", edit_user_path, class: "change"
       .confirm_adress__zip_code 
         〒
         = current_user.addresses[0].zip

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,0 +1,160 @@
+=render 'layouts/error_messages', model: current_user
+.top_icon
+  =image_tag(asset_path("logo.png"))
+- breadcrumb :sign_up
+= render "layouts/breadcrumbs"
+%main.wrapper-sign-up
+  %article.wrapper-sign-up__article
+    =  form_with url: edit_user_path, local: true do |f|
+      %section.wrapper-sign-up__article__section__title
+        %h1.wrapper-sign-up__article__section__title--top ユーザー新規登録
+      %section.wrapper-sign-up__article__section
+        %h2.wrapper-sign-up__article__section--title ユーザ登録情報
+        .wrapper-sign-up__article__section__form-area
+          .wrapper-sign-up__article__section__form-area__name
+            ニックネーム
+            .wrapper-sign-up__article__section__form-area__name__attribute--box
+              必須
+          .wrapper-sign-up__article__section__form-area__form
+            =f.text_field :nickname, class: "wrapper-sign-up__article__section__form-area__form--style", maxlength: "30"
+        .wrapper-sign-up__article__section__form-area
+          .wrapper-sign-up__article__section__form-area__name
+            メールアドレス
+            .wrapper-sign-up__article__section__form-area__name__attribute--box
+              必須
+          .wrapper-sign-up__article__section__form-area__form
+            =f.email_field :email, class: "wrapper-sign-up__article__section__form-area__form--style", maxlength: "256"
+        .wrapper-sign-up__article__section__form-area
+          .wrapper-sign-up__article__section__form-area__name
+            パスワード
+            .wrapper-sign-up__article__section__form-area__name__attribute--box
+              必須
+          .wrapper-sign-up__article__section__form-area__form
+            =f.password_field :password, class: "wrapper-sign-up__article__section__form-area__form--style", placeholder: "7文字以上", maxlength: "30"
+        .wrapper-sign-up__article__section__form-area
+          .wrapper-sign-up__article__section__form-area__name
+            パスワード(確認用)
+            .wrapper-sign-up__article__section__form-area__name__attribute--box
+              必須
+          .wrapper-sign-up__article__section__form-area__form
+            =f.password_field :password_confirmation, class: "wrapper-sign-up__article__section__form-area__form--style", placeholder: "7文字以上", maxlength: "30"
+        %hr
+      %section.wrapper-sign-up__article__section
+        %h2.wrapper-sign-up__article__section--title 本人確認情報
+        .wrapper-sign-up__article__section__form-area
+          .wrapper-sign-up__article__section__form-area__name
+            名前
+            .wrapper-sign-up__article__section__form-area__name__attribute--box
+              必須
+          .wrapper-sign-up__article__section__form-area__form
+            .wrapper-sign-up__article__section__form-area__form__divide
+              .wrapper-sign-up__article__section__form-area__form__divide__text 姓
+              =f.text_field :lastname, class: "wrapper-sign-up__article__section__form-area__form--style", placeholder: "全角", maxlength: "30"
+            .wrapper-sign-up__article__section__form-area__form__divide
+              .wrapper-sign-up__article__section__form-area__form__divide__text 名
+              =f.text_field :firstname, class: "wrapper-sign-up__article__section__form-area__form--style", placeholder: "全角", maxlength: "30"
+        .wrapper-sign-up__article__section__form-area
+          .wrapper-sign-up__article__section__form-area__name
+            ふりがな
+            .wrapper-sign-up__article__section__form-area__name__attribute--box
+              必須
+          .wrapper-sign-up__article__section__form-area__form
+            .wrapper-sign-up__article__section__form-area__form__divide
+              .wrapper-sign-up__article__section__form-area__form__divide__text 姓
+              =f.text_field :lastname_read, class: "wrapper-sign-up__article__section__form-area__form--style", placeholder: "全角", maxlength: "30"
+            .wrapper-sign-up__article__section__form-area__form__divide
+              .wrapper-sign-up__article__section__form-area__form__divide__text 名
+              =f.text_field :firstname_read, class: "wrapper-sign-up__article__section__form-area__form--style", placeholder: "全角", maxlength: "30"
+        .wrapper-sign-up__article__section__form-area
+          .wrapper-sign-up__article__section__form-area__name
+            誕生日
+            .wrapper-sign-up__article__section__form-area__name__attribute--box
+              必須
+          .wrapper-sign-up__article__section__form-area__form
+            =raw sprintf(f.date_select(:birthday,  default: Time.now , start_year: 1960, end_year: Time.now.year, use_month_numbers: true, date_separator: "%s", with_css_classes: "date"), "年 ", "月 ")+ "日"
+        %hr
+      %section.wrapper-sign-up__article__section
+        %h2.wrapper-sign-up__article__section--title 商品送付先
+        =f.fields_for :addresses, @address do |address_f|
+          .wrapper-sign-up__article__section__form-area
+            .wrapper-sign-up__article__section__form-area__name
+              名前
+              .wrapper-sign-up__article__section__form-area__name__attribute--box
+                必須
+            .wrapper-sign-up__article__section__form-area__form
+              .wrapper-sign-up__article__section__form-area__form__divide
+                .wrapper-sign-up__article__section__form-area__form__divide__text 姓
+                =address_f.text_field :lastname, class: "wrapper-sign-up__article__section__form-area__form--style", maxlength: "30"
+              .wrapper-sign-up__article__section__form-area__form__divide
+                .wrapper-sign-up__article__section__form-area__form__divide__text 名
+                =address_f.text_field :firstname, class: "wrapper-sign-up__article__section__form-area__form--style", maxlength: "30"
+          .wrapper-sign-up__article__section__form-area
+            .wrapper-sign-up__article__section__form-area__name
+              ふりがな
+              .wrapper-sign-up__article__section__form-area__name__attribute--box
+                必須
+            .wrapper-sign-up__article__section__form-area__form
+              .wrapper-sign-up__article__section__form-area__form__divide
+                .wrapper-sign-up__article__section__form-area__form__divide__text 姓
+                =address_f.text_field :lastname_read, class: "wrapper-sign-up__article__section__form-area__form--style", maxlength: "30"
+              .wrapper-sign-up__article__section__form-area__form__divide
+                .wrapper-sign-up__article__section__form-area__form__divide__text 名
+                =address_f.text_field :firstname_read, class: "wrapper-sign-up__article__section__form-area__form--style", maxlength: "30"
+          .wrapper-sign-up__article__section__form-area
+            .wrapper-sign-up__article__section__form-area__name
+              郵便番号
+              .wrapper-sign-up__article__section__form-area__name__attribute--box
+                必須
+            .wrapper-sign-up__article__section__form-area__form
+              =address_f.text_field :first_zip, class: "wrapper-sign-up__article__section__form-area__form--style wrapper-sign-up__article__section__form-area__form--zip-first", maxlength: "3"
+              .wrapper-sign-up__article__section__form-area__form--zip-divide -
+              =address_f.text_field :last_zip, class: "wrapper-sign-up__article__section__form-area__form--style wrapper-sign-up__article__section__form-area__form--zip-second", maxlength: "4"
+          .wrapper-sign-up__article__section__form-area
+            .wrapper-sign-up__article__section__form-area__name
+              都道府県
+              .wrapper-sign-up__article__section__form-area__name__attribute--box
+                必須
+            .wrapper-sign-up__article__section__form-area__form
+              =address_f.text_field :prefecture, class: "wrapper-sign-up__article__section__form-area__form--style", maxlength: "30"
+          .wrapper-sign-up__article__section__form-area
+            .wrapper-sign-up__article__section__form-area__name
+              市区町村
+              .wrapper-sign-up__article__section__form-area__name__attribute--box
+                必須
+            .wrapper-sign-up__article__section__form-area__form
+              =address_f.text_field :city, class: "wrapper-sign-up__article__section__form-area__form--style", maxlength: "30"
+          .wrapper-sign-up__article__section__form-area
+            .wrapper-sign-up__article__section__form-area__name
+              番地
+              .wrapper-sign-up__article__section__form-area__name__attribute--box
+                必須
+            .wrapper-sign-up__article__section__form-area__form
+              =address_f.text_field :address_line, class: "wrapper-sign-up__article__section__form-area__form--style", maxlength: "30"
+          .wrapper-sign-up__article__section__form-area
+            .wrapper-sign-up__article__section__form-area__name
+              建物名
+              .wrapper-sign-up__article__section__form-area__name__attribute--box.wrapper-sign-up__article__section__form-area__name__attribute--optional
+                任意
+            .wrapper-sign-up__article__section__form-area__form
+              =address_f.text_field :building, class: "wrapper-sign-up__article__section__form-area__form--style", maxlength: "30"
+          .wrapper-sign-up__article__section__form-area
+            .wrapper-sign-up__article__section__form-area__name
+              部屋番号
+              .wrapper-sign-up__article__section__form-area__name__attribute--box.wrapper-sign-up__article__section__form-area__name__attribute--optional
+                任意
+            .wrapper-sign-up__article__section__form-area__form
+              =address_f.text_field :room, class: "wrapper-sign-up__article__section__form-area__form--style", maxlength: "30"
+          .wrapper-sign-up__article__section__form-area
+            .wrapper-sign-up__article__section__form-area__name
+              TEL
+              .wrapper-sign-up__article__section__form-area__name__attribute--box.wrapper-sign-up__article__section__form-area__name__attribute--optional
+                任意
+            .wrapper-sign-up__article__section__form-area__form
+              =address_f.text_field :first_telephone, class: "wrapper-sign-up__article__section__form-area__form--style wrapper-sign-up__article__section__form-area__form--tel-two", maxlength: "4"
+              .wrapper-sign-up__article__section__form-area__form--tel-divide -
+              =address_f.text_field :second_telephone, class: "wrapper-sign-up__article__section__form-area__form--style wrapper-sign-up__article__section__form-area__form--tel-four", maxlength: "4"
+              .wrapper-sign-up__article__section__form-area__form--tel-divide -
+              =address_f.text_field :third_telephone, class: "wrapper-sign-up__article__section__form-area__form--style wrapper-sign-up__article__section__form-area__form--tel-four", maxlength: "4"
+          %hr
+      = f.submit "登録", class: "wrapper-sign-up__article__section--btn"
+.bottom_area

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {registrations: 'users/registrations'}
-  resources :users, only: [:show] do
+  resources :users, only: [:show, :edit, :update] do
     collection do
       get 'sale_items'
       get 'sold_items'


### PR DESCRIPTION
＃what
変更するボタンに機能がなかったため、追加実装
クレジットカードを変更するを押すと、クレジットカード登録ページへ
登録情報変更するを押すと、ユーザー情報登録ページへ

＃why
登録情報変更をしやすくするため